### PR TITLE
Added function to repeatedly check for long run jobs and log it

### DIFF
--- a/core/src/main/java/org/jobrunr/server/BackgroundJobServer.java
+++ b/core/src/main/java/org/jobrunr/server/BackgroundJobServer.java
@@ -21,6 +21,7 @@ import org.jobrunr.server.tasks.startup.ShutdownExecutorServiceTask;
 import org.jobrunr.server.tasks.startup.StartupTask;
 import org.jobrunr.server.tasks.zookeeper.DeleteDeletedJobsPermanentlyTask;
 import org.jobrunr.server.tasks.zookeeper.DeleteSucceededJobsTask;
+import org.jobrunr.server.tasks.zookeeper.LongRunningJobsTask;
 import org.jobrunr.server.tasks.zookeeper.ProcessOrphanedJobsTask;
 import org.jobrunr.server.tasks.zookeeper.ProcessRecurringJobsTask;
 import org.jobrunr.server.tasks.zookeeper.ProcessScheduledJobsTask;
@@ -366,8 +367,17 @@ public class BackgroundJobServer implements BackgroundJobServerMBean {
         JobZooKeeper orphanedJobsZooKeeper = new JobZooKeeper(this, new ProcessOrphanedJobsTask(this));
         /*
          * Added heartbeat zookeeper here, to update in progress jobs
+         *   UpdateJobsInProgressZooKeeperTask (the commented-out one):
+                - Fetches ALL jobs in PROCESSING across ALL servers
+                - Blindly updates their timestamps
+                - Can't detect if a job is stuck!
+                - If the worker thread is frozen/crashed, this task would still update the timestamp
+                - Orphan detection becomes useless
          */
+
+        //The below line was commented out as the master does not process any jobs now
         // JobZooKeeper inProgressZookeeper = new JobZooKeeper(this, new UpdateJobsInProgressZooKeeperTask(this));
+        JobZooKeeper longRunningJobsZooKeeper = new JobZooKeeper(this, new LongRunningJobsTask(this));
         JobZooKeeper janitorZooKeeper = new JobZooKeeper(this, new DeleteSucceededJobsTask(this), new DeleteDeletedJobsPermanentlyTask(this));
         LOGGER.info("[ZOOKEEPER]: JobZooKeepers created successfully");
         
@@ -376,6 +386,9 @@ public class BackgroundJobServer implements BackgroundJobServerMBean {
         zookeeperThreadPool.scheduleWithFixedDelay(scheduledJobsZooKeeper, delay, configuration.getPollInterval().toMillis(), TimeUnit.MILLISECONDS);
         zookeeperThreadPool.scheduleWithFixedDelay(orphanedJobsZooKeeper, delay, configuration.getPollInterval().toMillis(), TimeUnit.MILLISECONDS);
         // zookeeperThreadPool.scheduleWithFixedDelay(inProgressZookeeper, delay, configuration.getPollInterval().toMillis(), TimeUnit.MILLISECONDS);
+
+        //We need to run it less frequently
+        zookeeperThreadPool.scheduleWithFixedDelay(longRunningJobsZooKeeper, delay, configuration.getPollInterval().toMillis() * 2, TimeUnit.MILLISECONDS);
         zookeeperThreadPool.scheduleWithFixedDelay(janitorZooKeeper, delay, configuration.getPollInterval().toMillis(), TimeUnit.MILLISECONDS);
         LOGGER.info("[ZOOKEEPER]: JobZooKeepers scheduled successfully");
     }

--- a/core/src/main/java/org/jobrunr/server/tasks/Task.java
+++ b/core/src/main/java/org/jobrunr/server/tasks/Task.java
@@ -46,7 +46,7 @@ public abstract class Task {
             this.runInfo = runInfo;
             // We need to make sure we finish PROCESS RECURRING TASKS before poll interval gets over
             if (pollIntervalInSecondsTimeBoxIsAboutToPass()){
-                LOGGER.info("[ZOOKEEPER][TIMEOUT]: Poll interval in seconds time box is about to pass. Returning.");
+                LOGGER.warn("[ZOOKEEPER][TIMEOUT]: Poll interval in seconds time box is about to pass. Returning.");
                 return;
             }
             long startTime = System.nanoTime();

--- a/core/src/main/java/org/jobrunr/server/tasks/steward/UpdateJobsInProgressTask.java
+++ b/core/src/main/java/org/jobrunr/server/tasks/steward/UpdateJobsInProgressTask.java
@@ -1,6 +1,7 @@
 package org.jobrunr.server.tasks.steward;
 
 import java.util.Set;
+import java.util.UUID;
 
 import org.jobrunr.jobs.Job;
 import org.jobrunr.server.BackgroundJobServer;
@@ -20,20 +21,28 @@ public class UpdateJobsInProgressTask extends AbstractJobStewardTask {
     @Override
     protected void runTask() {
         Set<Job> jobsInProgress = backgroundJobServer.getJobSteward().getJobsInProgress();
-        String jobIds = jobsInProgress.stream()
-                .map(job -> job.getId().toString())
-                .collect(java.util.stream.Collectors.joining(", "));
-        LOGGER.debug("Updating currently processed jobs. Job IDs: [{}]", jobIds);
+        UUID serverId = backgroundJobServer.getId();
+
+        if (jobsInProgress.isEmpty()) {
+            LOGGER.debug("[UPDATE JOBS IN PROGRESS] [serverId:{}] No jobs currently in progress to update", serverId);
+            return;
+        }
         convertAndProcessJobs(jobsInProgress, this::updateCurrentlyProcessingJob);
     }
 
     private Job updateCurrentlyProcessingJob(Job job) {
         try {
+            UUID serverId = backgroundJobServer.getId();
+            LOGGER.info("[UPDATE JOBS IN PROGRESS] [serverId:{}] [id:{}] [recurringJobId:{}] [jobName:{}] updating timestamp to keep job alive",
+                        serverId, job.getId(), job.getRecurringJobId().orElse(null), job.getJobName());
             return job.updateProcessing();
         } catch (ClassCastException e) {
             // why: there is a tiny chance that the job already succeeded or failed.
             // For example, if the underlying data structure is a concurrent collection and the iteration is weakly
             // consistent, it might return items in its iterator that have already been removed from the collection.
+            UUID serverId = backgroundJobServer.getId();
+            LOGGER.warn("[UPDATE JOBS IN PROGRESS] [serverId:{}] [id:{}] Job state changed during update (likely completed)",
+                       serverId, job.getId());
             return null;
         }
     }

--- a/core/src/main/java/org/jobrunr/server/tasks/zookeeper/LongRunningJobsTask.java
+++ b/core/src/main/java/org/jobrunr/server/tasks/zookeeper/LongRunningJobsTask.java
@@ -1,0 +1,69 @@
+package org.jobrunr.server.tasks.zookeeper;
+
+import org.jobrunr.jobs.Job;
+import org.jobrunr.server.BackgroundJobServer;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+public class LongRunningJobsTask extends AbstractJobZooKeeperTask {
+
+    private final Duration longRunningThreshold;
+    private final Duration recentlyUpdatedWindow;
+
+    public LongRunningJobsTask(BackgroundJobServer backgroundJobServer) {
+        super(backgroundJobServer);
+
+        // Threshold for considering a job as long-running (default: 5 minutes)
+        this.longRunningThreshold = Duration.ofMinutes(
+            Optional.ofNullable(System.getenv("JOBRUNR_LONG_RUNNING_JOB_THRESHOLD"))
+                .map(threshold -> {
+                    try {
+                        int minutes = Integer.parseInt(threshold);
+                        return Math.max(1, minutes); // At least 1 minute
+                    } catch (NumberFormatException e) {
+                        return 5; // Default to 5 minutes
+                    }
+                })
+                .orElse(5)
+        );
+
+        // Only consider jobs that are still actively being updated (within 2x poll interval)
+        this.recentlyUpdatedWindow = backgroundJobServer.getConfiguration().getPollInterval().multipliedBy(2);
+    }
+
+    @Override
+    protected void runTask() {
+        LOGGER.debug("[LONG RUNNING JOB]: Looking for long-running jobs...");
+
+        //We do this so that we only get jobs which are not orphaned.
+        Instant updatedAfter = Instant.now().minus(recentlyUpdatedWindow);
+        List<Job> longRunningJobs = storageProvider.getLongRunningJobs(longRunningThreshold, updatedAfter);
+
+        if (longRunningJobs.isEmpty()) {
+            LOGGER.debug("[LONG RUNNING JOB]: No long-running jobs found");
+            return;
+        }
+
+        LOGGER.info("[LONG RUNNING JOB]: Found {} long-running jobs", longRunningJobs.size());
+
+        for (Job job : longRunningJobs) {
+            logLongRunningJob(job);
+        }
+    }
+
+    private void logLongRunningJob(Job job) {
+        Duration jobDuration = Duration.between(job.getCreatedAt(), job.getUpdatedAt());
+        long durationMinutes = jobDuration.toMinutes();
+
+        LOGGER.info("[LONG RUNNING JOB] [id:{}] [recurringJobId:{}] [jobName:{}] [state:{}] [duration:{}m] Job has been running for longer than threshold ({}m)",
+                job.getId(),
+                job.getRecurringJobId().orElse(null),
+                job.getJobName(),
+                job.getState(),
+                durationMinutes,
+                longRunningThreshold.toMinutes());
+    }
+}

--- a/core/src/main/java/org/jobrunr/server/tasks/zookeeper/ProcessOrphanedJobsTask.java
+++ b/core/src/main/java/org/jobrunr/server/tasks/zookeeper/ProcessOrphanedJobsTask.java
@@ -21,7 +21,9 @@ public class ProcessOrphanedJobsTask extends AbstractJobZooKeeperTask {
         this.pageRequestSize = backgroundJobServer.getConfiguration().getOrphanedJobsRequestSize();
         // this.serverTimeoutDuration = backgroundJobServer.getConfiguration().getPollInterval().multipliedBy(backgroundJobServer.getConfiguration().getServerTimeoutPollIntervalMultiplicand());
         /*
-         * Updating this to handle long running jobs
+         * Updating this to handle long running jobs.
+         * Orphan jobs = jobs which were spawned by servers who are now dead. If we have a really large value we will not know if a server is dead.
+         * We need to have a very short value ideally like a few minutes at max
          */
         
         this.serverTimeoutDuration = Duration.ofMinutes(
@@ -29,12 +31,12 @@ public class ProcessOrphanedJobsTask extends AbstractJobZooKeeperTask {
                 .map(timeout -> {
                     try {
                         int minutes = Integer.parseInt(timeout);
-                        return Math.max(1, Math.min(minutes, 1440)); // Clamp between 1-1440 minutes (1 day)
+                        return Math.max(1, Math.min(minutes, 10)); // Clamp between 1-10 minutes
                     } catch (NumberFormatException e) {
-                        return 20;
+                        return 2; //Default to 2
                     }
                 })
-                .orElse(20)
+                .orElse(2)
         );
     }
 

--- a/core/src/main/java/org/jobrunr/storage/InMemoryStorageProvider.java
+++ b/core/src/main/java/org/jobrunr/storage/InMemoryStorageProvider.java
@@ -23,7 +23,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
-
+import java.time.Duration;
 import static java.lang.Long.parseLong;
 import static java.util.Arrays.asList;
 import static java.util.Comparator.comparing;
@@ -403,5 +403,9 @@ public class InMemoryStorageProvider extends AbstractStorageProvider {
 
     public long countRecurringJobs() {
         return 0L;
+    }
+
+    public List<Job> getLongRunningJobs(Duration minDuration, Instant updatedAfter) {
+        return null; 
     }
 }

--- a/core/src/main/java/org/jobrunr/storage/StorageProvider.java
+++ b/core/src/main/java/org/jobrunr/storage/StorageProvider.java
@@ -163,6 +163,20 @@ public interface StorageProvider extends AutoCloseable {
      */
     List<Job> getJobList(StateName state, AmountRequest amountRequest);
 
+    /**
+     * Returns jobs that have been running longer than the specified minimum duration.
+     * Only includes jobs that:
+     * - Are in ENQUEUED or PROCESSING state
+     * - Have scheduledAt as NULL (not scheduled jobs)
+     * - Were updated recently (updatedAt >= updatedAfter)
+     * - Have been running longer than minDuration (updatedAt - createdAt > minDuration)
+     *
+     * @param minDuration  the minimum duration a job must be running to be included
+     * @param updatedAfter only include jobs updated after this instant (to filter out stale jobs)
+     * @return a list of long-running jobs matching the criteria
+     */
+    List<Job> getLongRunningJobs(Duration minDuration, Instant updatedAfter);
+
     default Page<Job> getJobs(StateName state, PageRequest pageRequest) {
         long totalJobs = countJobs(state);
         if (totalJobs == 0) return pageRequest.emptyPage();

--- a/core/src/main/java/org/jobrunr/storage/ThreadSafeStorageProvider.java
+++ b/core/src/main/java/org/jobrunr/storage/ThreadSafeStorageProvider.java
@@ -150,6 +150,11 @@ public class ThreadSafeStorageProvider implements StorageProvider {
     }
 
     @Override
+    public List<Job> getLongRunningJobs(Duration minDuration, Instant updatedAfter) {
+        return storageProvider.getLongRunningJobs(minDuration, updatedAfter);
+    }
+
+    @Override
     public List<Job> getJobsToProcess(BackgroundJobServer backgroundJobServer, AmountRequest amountRequest) {
         return storageProvider.getJobsToProcess(backgroundJobServer, amountRequest);
     }

--- a/core/src/main/java/org/jobrunr/storage/nosql/elasticsearch/ElasticSearchStorageProvider.java
+++ b/core/src/main/java/org/jobrunr/storage/nosql/elasticsearch/ElasticSearchStorageProvider.java
@@ -907,4 +907,9 @@ public class ElasticSearchStorageProvider extends AbstractStorageProvider implem
     public Map<String, Long> recurringJobsExistsByHours(long hourMask, StateName... states) {
         return null; // Not implemented for ElasticSearchStorageProvider
     }
+
+    @Override
+    public List<Job> getLongRunningJobs(java.time.Duration minDuration, Instant updatedAfter) {
+        return null; // Not implemented for ElasticSearchStorageProvider
+    }
 }

--- a/core/src/main/java/org/jobrunr/storage/nosql/mongo/MongoDBStorageProvider.java
+++ b/core/src/main/java/org/jobrunr/storage/nosql/mongo/MongoDBStorageProvider.java
@@ -609,4 +609,9 @@ public class MongoDBStorageProvider extends AbstractStorageProvider implements N
         return null; // Not implemented for MongoDBStorageProvider
     }
 
+    @Override
+    public List<Job> getLongRunningJobs(java.time.Duration minDuration, Instant updatedAfter) {
+        return null; // Not implemented for MongoDBStorageProvider
+    }
+
 }

--- a/core/src/main/java/org/jobrunr/storage/nosql/redis/JedisRedisStorageProvider.java
+++ b/core/src/main/java/org/jobrunr/storage/nosql/redis/JedisRedisStorageProvider.java
@@ -693,4 +693,9 @@ public class JedisRedisStorageProvider extends AbstractStorageProvider implement
     public Map<String, Long> recurringJobsExistsByHours(long hourMask, StateName... states) {
         return null; // Not implemented for JedisRedisStorageProvider
     }
+
+    @Override
+    public List<Job> getLongRunningJobs(Duration minDuration, Instant updatedAfter) {
+        return null; // Not implemented for JedisRedisStorageProvider
+    }
 }

--- a/core/src/main/java/org/jobrunr/storage/nosql/redis/LettuceRedisStorageProvider.java
+++ b/core/src/main/java/org/jobrunr/storage/nosql/redis/LettuceRedisStorageProvider.java
@@ -778,4 +778,9 @@ public class LettuceRedisStorageProvider extends AbstractStorageProvider impleme
     public Map<String, Long> recurringJobsExistsByHours(long hourMask, StateName... states) {
         return null; // Not implemented for LettuceRedisStorageProvider
     }
+
+    @Override
+    public List<Job> getLongRunningJobs(Duration minDuration, Instant updatedAfter) {
+        return null; // Not implemented for LettuceRedisStorageProvider
+    }
 }

--- a/core/src/main/java/org/jobrunr/storage/sql/common/DefaultSqlStorageProvider.java
+++ b/core/src/main/java/org/jobrunr/storage/sql/common/DefaultSqlStorageProvider.java
@@ -38,6 +38,7 @@ import java.util.LinkedHashMap;
 import java.sql.Timestamp;
 import java.util.Calendar;
 import java.util.TimeZone;
+import java.time.Duration;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.jobrunr.jobs.states.StateName.PROCESSING;
@@ -303,6 +304,38 @@ public class DefaultSqlStorageProvider extends AbstractStorageProvider implement
             LOGGER.info("[FETCHED SCHEDULED JOBS]: Fetched " + savedJobs.size() + " jobs in: " + duration + "ms");
             return savedJobs;
         } catch (SQLException e) {
+            throw new StorageException(e);
+        }
+    }
+
+    @Override
+    public List<Job> getLongRunningJobs(Duration minDuration, Instant updatedAfter) {
+        String sql =
+            "SELECT jobAsJson " +
+            "  FROM jobrunr_jobs " +
+            " WHERE (state = 'ENQUEUED' OR state = 'PROCESSING') " +
+            "   AND scheduledAt IS NULL " +
+            "   AND updatedAt >= ? " +
+            "   AND TIMESTAMPDIFF(SECOND, createdAt, updatedAt) > ?";
+
+        try (Connection conn = dataSource.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+
+            ps.setTimestamp(1, Timestamp.from(updatedAfter));
+            ps.setLong(2, minDuration.getSeconds());
+
+            try (ResultSet rs = ps.executeQuery()) {
+                List<Job> jobs = new ArrayList<>();
+                while (rs.next()) {
+                    String jobAsJson = rs.getString("jobAsJson");
+                    Job job = jobMapper.deserializeJob(jobAsJson);
+                    jobs.add(job);
+                }
+                return jobs;
+            }
+
+        } catch (SQLException e) {
+            LOGGER.error("Error running getLongRunningJobs", e);
             throw new StorageException(e);
         }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Detects and logs long-running jobs with a configurable threshold; the check runs less frequently to reduce overhead.

- Chores
  - Added retrieval support for long-running jobs across storage providers (fully implemented for SQL; others prepared for future support).
  - Shortened default orphaned job timeout to 2 minutes (configurable, clamped to 1–10 minutes).
  - Elevated a timeout message to warning level and improved logging for in-progress job updates to aid troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->