### PR TITLE
HOTFIX - increase long run job check to 10 minutes, assuming 30 secon…

### DIFF
--- a/core/src/main/java/org/jobrunr/server/BackgroundJobServer.java
+++ b/core/src/main/java/org/jobrunr/server/BackgroundJobServer.java
@@ -388,7 +388,7 @@ public class BackgroundJobServer implements BackgroundJobServerMBean {
         // zookeeperThreadPool.scheduleWithFixedDelay(inProgressZookeeper, delay, configuration.getPollInterval().toMillis(), TimeUnit.MILLISECONDS);
 
         //We need to run it less frequently
-        zookeeperThreadPool.scheduleWithFixedDelay(longRunningJobsZooKeeper, delay, configuration.getPollInterval().toMillis() * 2, TimeUnit.MILLISECONDS);
+        zookeeperThreadPool.scheduleWithFixedDelay(longRunningJobsZooKeeper, delay, configuration.getPollInterval().toMillis() * 20, TimeUnit.MILLISECONDS);
         zookeeperThreadPool.scheduleWithFixedDelay(janitorZooKeeper, delay, configuration.getPollInterval().toMillis(), TimeUnit.MILLISECONDS);
         LOGGER.info("[ZOOKEEPER]: JobZooKeepers scheduled successfully");
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Adjusted the background monitoring interval for long-running jobs, making maintenance checks less frequent.
  - Expected impact: reduced background overhead and resource usage, with potentially smoother performance under load.
  - No changes to user-facing features or configuration are required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->